### PR TITLE
Registry location override

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ with each port.
 The registry lives in ~/.ports.json
 
 Export an environment variable to overide the location for the registry:
-    export PORTSHOME=/some/valid/directory
+
+```
+export PORTSHOME=/some/valid/directory
+```
 
 Note that this module currently doesn’t check whether
 a port is actually available. That’s TBD.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Manage a registry of unique port assignments for
 an operating system. Store user-defined meta-data
 with each port.
 
-The registry lives in ~/.ports
+The registry lives in ~/.ports.json
+
+Export an environment variable to overide the location for the registry:
+    export PORTSHOME=/some/valid/directory
 
 Note that this module currently doesn’t check whether
 a port is actually available. That’s TBD.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with each port.
 
 The registry lives in ~/.ports.json
 
-Export an environment variable to overide the location for the registry:
+Export an environment variable to override the location for the registry:
 
 ```
 export PORTSHOME=/some/valid/directory

--- a/index.js
+++ b/index.js
@@ -55,9 +55,13 @@ var write_json = function write_json(filename, value) {
 };
 
 function getPortsFile() {
-  var homedir = "HOME";
-  if(process.platform === "win32") {
-    homedir = "USERPROFILE";
+  if (process.env.PORTSHOME !== undefined) {
+      var homedir = "PORTSHOME";
+  } else {
+      var homedir = "HOME";
+      if(process.platform === "win32") {
+        homedir = "USERPROFILE";
+      }
   }
   return path.join(process.env[homedir],".ports.json");
 };


### PR DESCRIPTION
Here's a relatively minor change to allow for the .ports.json location to be optionally defined with an exported environment variable.
